### PR TITLE
Updated processes for BAM indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 *.DS_Store
 # Nextflow files
 .nextflow*
+# FASTQ files
+*.fastq
+*.fq
+*.fq.gz

--- a/main.nf
+++ b/main.nf
@@ -2,7 +2,7 @@ nextflow.enable.dsl=2
 include { bbduk } from './trim_reads'
 include { runFastqc; runMultiQC } from './dataqc'
 include { bowtie_Align } from './bowtie'
-include { sam_to_bam; bam_sort; bam_index; keep_unaligned; coverage } from './samview'
+include { sam_to_bam;bam_sort;coverage } from './samview'
 
 workflow alignAndCoverage {
   fastq_path = Channel.fromFilePairs(params.fastq_path, size: 4)
@@ -15,8 +15,7 @@ workflow alignAndCoverage {
     bowtie_Align(bbduk.out.trimmed_reads, index_path)
     sam_to_bam(bowtie_Align.out.sam_path)
     bam_sort(sam_to_bam.out.bam_files)
-    bam_index(bam_sort.out.sorted_bam_file)
-    coverage(bam_index.out.indexed_path)
+    coverage(bam_sort.out.sorted_bam_file)
 }
 
 workflow trimReadsandQC {


### PR DESCRIPTION
- Removed a separate bam_index process
- Integrated BAM indexing into the sam_to_bam and bam_sort processes
- Removed include call for bam_index in main
- Updated gitignore with FASTQ extensions
- Emit channel from sam_to_bam and bam_sort now emit a tuple with sample name, BAM file path, and BAM index path.